### PR TITLE
Explicitely reference shortcut icon

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -3,6 +3,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>{{ page.title }} - {{ site.title }}</title>
     <link rel="stylesheet" href="{{ site.baseurl }}/assets/css/app.css">
+    <link rel="shortcut icon" type="image/png" href="{{ site.baseurl }}/favicon.png" />
     <script defer src="https://use.fontawesome.com/releases/v5.3.1/js/all.js"></script>
     {% seo %}
     {%- if site.google_analytics -%}


### PR DESCRIPTION
This fixes the url by respecting Jekylls `site.baseurl` and uses png icons which seem to be better supported than ico icons.