### PR TITLE
Remove hardcoded size

### DIFF
--- a/_includes/callouts.html
+++ b/_includes/callouts.html
@@ -1,6 +1,6 @@
 {% if page.callouts %}
     {% assign callouts=site.data.[page.callouts] %}
-    <section class="hero {{ callouts.style }}">
+    <section class="hero {% if callouts.height %} {{ callouts.height }} {% else %} is-medium {% endif %} {{ callouts.style }}">
         <div class="hero-body">
             <div class="container">
                 <div class="columns is-multiline is-centered">

--- a/_includes/callouts.html
+++ b/_includes/callouts.html
@@ -1,6 +1,6 @@
 {% if page.callouts %}
     {% assign callouts=site.data.[page.callouts] %}
-    <section class="hero is-medium {{ callouts.style }}">
+    <section class="hero {{ callouts.style }}">
         <div class="hero-body">
             <div class="container">
                 <div class="columns is-multiline is-centered">


### PR DESCRIPTION
Remove hardcoded callout size of `is-medium` and instead, let it be set by style attribute in callouts yaml.

For example `home_callouts.yaml`
```
style: is-light is-small
```