### PR TITLE
Added `page.no_hero` to allow skipping hero section.

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -10,7 +10,9 @@
   {% include head.html %}
   <body>
     {% include header.html %}
-    {% include hero.html %}
+    {% unless page.no_hero %}
+        {% include hero.html %}
+    {% endunless %}
     {% include callouts.html %}
     <section class="section">
         <div class="container">

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -10,7 +10,7 @@
   {% include head.html %}
   <body>
     {% include header.html %}
-    {% unless page.no_hero %}
+    {% unless page.hide_hero %}
         {% include hero.html %}
     {% endunless %}
     {% include callouts.html %}


### PR DESCRIPTION
The current implementation allows setting `page.hero_height`, which can be one of `is-small`, `is-medium`, `is-large`. There is no user option to disable hero completely. This patch adds `page.no_hero`, which when set, completely disables the hero section.

I like the style, but hero takes too much of the vertical space (even when `is-small`), plus I prefer to render the page title using Markdown, so it shows as a page title also when rendered directly by GitHub or VS Code markdown preview.

On the other hand, I guess I can just copy `default.html` to my site's `_layouts`, remove the hero include, call it `no_hero.html` and use this as a default layout. And since I am also no web dev, with no experience with Jekyll, I could be totally off. So I am leaving this PR here more as question, if anything like this would make sense, or am I addressing this from the wrong end?