### PR TITLE
Update(gemspec)

### DIFF
--- a/bulma-clean-theme.gemspec
+++ b/bulma-clean-theme.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
 
   spec.files         = `git ls-files -z`.split("\x0").select { |f| f.match(%r!^(assets|_layouts|_includes|_sass|_posts|blog|LICENSE|README|package|node_modules|favicon)!i) }
 
-  spec.add_runtime_dependency "jekyll", "~> 3.8"
+  spec.add_runtime_dependency "jekyll", "~> 4.0"
   spec.add_runtime_dependency "jekyll-feed", "~> 0.11"
   spec.add_runtime_dependency "jekyll-sitemap", "~> 1.2"
   spec.add_runtime_dependency "jekyll-paginate", "~> 1.1"


### PR DESCRIPTION
This theme requires version 3.8 of jekyll. 4.0 is the latest version. I updated the gemspec. This closes #37 