### PR TITLE
Fix pagination link to first page

### DIFF
--- a/_includes/pagination.html
+++ b/_includes/pagination.html
@@ -14,7 +14,7 @@
         {% if page == paginator.page %}
         <li><a class="pagination-link is-current">{{ page }}</a></li>
         {% elsif page == 1 %}
-        <li><a href="{{ paginator.previous_page_path | prepend: site.baseurl | replace: '//', '/' }}" class="pagination-link">{{ page }}</a></li>
+        <li><a href="{{ site.paginate_path | prepend: site.baseurl | replace: '//', '/' | split: '/' | pop | join: '/' }}" class="pagination-link">{{ page }}</a></li>
         {% else %}
         <li><a href="{{ site.paginate_path | prepend: site.baseurl | replace: '//', '/' | replace: ':num', page }}" class="pagination-link">{{ page }}</a></li>
         {% endif %}


### PR DESCRIPTION
Thanks so much for this theme, I really like the way it looks, and I appreciate all the extra features.

I found that the pagination controls link the number 1 to the previous page instead of the first page, perhaps because you can't just link to `/blog/page1`. I've implemented the correct link by splitting on `/`, popping the `page:num` or whatever pattern is configured, and then rejoining on `/`. I think this is general enough to cover any configuration that the pagination module will support.