### PR TITLE
Remove Google Analytics

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,6 @@ This is a clean and simple Jekyll Theme built with the [Bulma](https://bulma.io/
     * [Sidebar Visibility](#sidebar-visibility)
     * [Menubar](#menubar)
     * [Tabs](#tabs)
-    * [Google Analytics](#google-analytics)
     * [Footer](#footer)
     * [Products](#products)
     * [Scripts](#scripts)
@@ -253,13 +252,6 @@ It will automatically mark the active tab based on the current page.
 You can add icons to your tab by passing in the [Font Awesome icon class](https://fontawesome.com/icons?d=gallery).
 
 If you don't wish to show icons then simply omit the option from your yaml file.
-
-
-### Google Analytics 
-
-**New in 0.2**
-
-To enable Google Analytics add `google_analytics: UA-xxxxxxxx` to your `_config.yml` replacing the UA-xxxxxxxx with your Google Analytics property
 
 ### Footer
 

--- a/_config.yml
+++ b/_config.yml
@@ -46,8 +46,6 @@ sass:
   style: compressed
   source_dir: _sass
 
-#google_analytics: UA-code-here
-
 defaults:
   -
     scope:

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -11,8 +11,5 @@
         <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bulma-social@1/bin/bulma-social.min.css">
     {% endunless %}
     {% seo %}
-    {%- if site.google_analytics -%}
-      {%- include google-analytics.html -%}
-    {%- endif -%}
     {%- include head-scripts.html -%}
 </head>


### PR DESCRIPTION
Would you be willing to remove this Google Analytics 'functionality' from this theme? There are better alternatives if you _must_ keep tabs on users' activity.

Some reputable alternatives can be seen here: https://switching.software/replace/google-analytics/