### PR TITLE
Replace prepend filter with absolute_url to support external links.

### DIFF
--- a/_includes/callouts.html
+++ b/_includes/callouts.html
@@ -25,7 +25,7 @@
                             {% endif %}
 
                             {% if callout.call_to_action_name %}
-                            <a href="{{ callout.call_to_action_link | prepend: site.baseurl }}" class="button is-primary">
+                            <a href="{{ callout.call_to_action_link | absolute_url }}" class="button is-primary">
                                 {{ callout.call_to_action_name }}
                             </a>
                             {% endif %}

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -6,7 +6,7 @@
             {% for item in site.data[site.footer_menu] %}
             <div class="column has-text-centered">
                 <div>
-                    <a href="{{ item.link | prepend: site.baseurl }}" class="link">{{ item.name }}</a>
+                    <a href="{{ item.link | absolute_url }}" class="link">{{ item.name }}</a>
                 </div>
             </div>
             {% endfor %}

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -4,7 +4,7 @@
     <title>{{ page.title }} - {{ site.title }}</title>
     <link rel="stylesheet" href="{{ site.baseurl }}/assets/css/app.css">
     <link rel="shortcut icon" type="image/png"
-          {% if site.favicon %} href="{{ site.favicon | prepend: site.baseurl }}" {% else %} href="{{ site.baseurl }}/favicon.png" {% endif %}
+          {% if site.favicon %} href="{{ site.favicon | absolute_url }}" {% else %} href="{{ site.baseurl }}/favicon.png" {% endif %}
     />
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@5/css/all.min.css">
     {% unless site.hide_share_buttons %}

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -18,15 +18,15 @@
                 {% for item in site.data.navigation %}
                     {% if item.dropdown %}
                     <div class="navbar-item has-dropdown is-hoverable">
-                        <a href="{{ item.link | prepend: site.baseurl }}" class="navbar-link {% if item.link == page.url %}is-active{% endif %}">{{ item.name }}</a>
+                        <a href="{{ item.link | absolute_url }}" class="navbar-link {% if item.link == page.url %}is-active{% endif %}">{{ item.name }}</a>
                         <div class="navbar-dropdown">
                             {% for subitem in item.dropdown %}
-                            <a href="{{ subitem.link | prepend: site.baseurl }}" class="navbar-item {% if subitem.link == page.url %}is-active{% endif %}">{{ subitem.name }}</a>
+                            <a href="{{ subitem.link | absolute_url }}" class="navbar-item {% if subitem.link == page.url %}is-active{% endif %}">{{ subitem.name }}</a>
                             {% endfor %}
                         </div>
                     </div>
                     {% else %}
-                    <a href="{{ item.link | prepend: site.baseurl }}" class="navbar-item {% if item.link == page.url %}is-active{% endif %}">{{ item.name }}</a>
+                    <a href="{{ item.link | absolute_url }}" class="navbar-item {% if item.link == page.url %}is-active{% endif %}">{{ item.name }}</a>
                     {% endif %}
                 {% endfor %}
                 {% endif %}

--- a/_includes/hero.html
+++ b/_includes/hero.html
@@ -4,7 +4,7 @@
             <h1 class="title is-2">{{ page.title }}</h1>
             <p class="subtitle is-3">{{ page.subtitle }}</p>
             {% if page.hero_link %}
-                <a href="{{ page.hero_link | prepend: site.baseurl  }}" class="button is-info is-large">{{ page.hero_link_text }}</a>
+                <a href="{{ page.hero_link | absolute_url }}" class="button is-info is-large">{{ page.hero_link_text }}</a>
             {% endif %}
         </div>
     </div>

--- a/_includes/menubar.html
+++ b/_includes/menubar.html
@@ -6,11 +6,11 @@
     <ul class="menu-list">
         {% for item in menu.items %}
         <li>
-            <a href="{{ item.link | prepend: site.baseurl }}" class="{% if item.link == page.url %}is-active{% endif %}">{{ item.name }}</a>
+            <a href="{{ item.link | absolute_url }}" class="{% if item.link == page.url %}is-active{% endif %}">{{ item.name }}</a>
             {% if item.items %}
             <ul>
                 {% for subitem in item.items %}
-                <li><a href="{{ subitem.link | prepend: site.baseurl }}" class="{% if subitem.link == page.url %}is-active{% endif %}">{{ subitem.name }}</a></li>
+                <li><a href="{{ subitem.link | absolute_url }}" class="{% if subitem.link == page.url %}is-active{% endif %}">{{ subitem.name }}</a></li>
                 {% endfor %}
             </ul>
             {% endif %}

--- a/_includes/showcase.html
+++ b/_includes/showcase.html
@@ -8,7 +8,7 @@
     {% for item in showcase.items %}
         <section class="showcase">
             <figure class="image {% if item.image_ratio %} {{ item.image_ratio }} {% else %} is-16by9 {% endif %}">
-                <img src="{{ item.image | prepend: site.baseurl }}" />
+                <img src="{{ item.image | absolute_url }}" />
             </figure>
             <div class="showcase-content">
                 <div class="columns is-centered">

--- a/_includes/tabs.html
+++ b/_includes/tabs.html
@@ -5,7 +5,7 @@
     <ul>
     {% for tab in tabs.items %}
         <li {% if tab.link == page.url %} class="is-active" {% endif %}>
-            <a href="{{ tab.link | prepend: site.baseurl }}">
+            <a href="{{ tab.link | absolute_url }}">
                 {% if tab.icon %}
                 <span class="icon is-small"><i class="fas {{ tab.icon }}" aria-hidden="true"></i></span>
                 {% endif %}

--- a/_layouts/product-category.html
+++ b/_layouts/product-category.html
@@ -14,7 +14,7 @@ show_sidebar: false
   {% for product in sorted_products %}
   <div class="column is-4-desktop is-6-tablet">
 
-    <a href="{{ product.url | prepend: site.baseurl }}">
+    <a href="{{ product.url | absolute_url }}">
 
       <div class="card">
 


### PR DESCRIPTION
This theme is working well on my GitHub pages, but I ran into a small problem. I can't use an external URL in the navigation links. For example, I tried adding this to the end of `navigation.yml`:

```
- name: GitHub
  link: https://github.com/chrisrhymes/bulma-clean-theme
```

Instead of using that link, though, it used this one: `http://localhost:4000/bulma-clean-themehttps://github.com/chrisrhymes/bulma-clean-theme`. Obviously, it's prepending the site's base URL to what's already an absolute URL. Luckily, Jekyll has a filter that does just what we need: [`absolute_url`]. It detects when its parameter is already absolute, and leaves it unchanged.

This PR replaces `prepend: site.baseurl` with `absolute_url` wherever I thought it made sense.

[`absolute_url`]: https://jekyllrb.com/docs/liquid/filters/