### PR TITLE
Active TOC in Menubar Layout

### DIFF
--- a/_includes/menubar.html
+++ b/_includes/menubar.html
@@ -1,6 +1,9 @@
 {% assign menus = site.data.[page.menubar] %}
 
-<aside class="menu">
+<aside class="menu{% if page.menubar_sticky %} sticky{% endif %}">
+{% if page.toc == "menubar" %}
+  {% include toc-wrapper.html %}
+{% else %}
 {% for menu in menus %}
     <p class="menu-label">{{ menu.label }}</p>
     <ul class="menu-list">
@@ -18,4 +21,11 @@
         {% endfor %}    
     </ul>
 {% endfor %}
+{% endif %}
 </aside>
+{% if page.menubar_sticky and page.toc == "menubar" %}
+<script src="{{ site.baseurl }}/assets/js/stickytoc.js" type="text/javascript"></script>
+<script type="text/javascript">
+  attachStickyMenuObserver({{ h_min }}, {{ h_max }});
+</script>
+{% endif %}

--- a/_includes/toc-wrapper.html
+++ b/_includes/toc-wrapper.html
@@ -1,0 +1,4 @@
+{% assign contentsTitle = page.toc_title | default: 'Contents' %}
+{% assign h_min = page.toc_min | default: site.toc_min | default: 2 %}
+{% assign h_max = page.toc_max | default: site.toc_max | default: 3 %}
+{% include toc.html html=content class='menu-list' h_min=h_min h_max=h_max contents_title=contentsTitle %}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -27,6 +27,9 @@
                     {% include showcase.html %}
                     {% include sponsors.html %}
                     {% include gallery.html %}
+                    {% if page.toc == true %}
+                      {% include toc-wrapper.html %}
+                    {% endif %}
                     {{ content }}
                 </div>
                 {% if site.posts and page.show_sidebar %}

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -2,10 +2,6 @@
 layout: default
 ---
 
-{% if page.toc %}
-    {% assign contentsTitle = page.toc_title | default: 'Contents' %}
-    {% include toc.html html=content class='menu-list' h_min=2 h_max=3 contents_title=contentsTitle %}
-{% endif %}
 <div class="content">
     {{ content }}
 </div>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -4,7 +4,7 @@ layout: default
 
 <div class="content">
 
-    <p>Published: {{ page.date | date: "%b %-d, %Y" }} by {{ page.author }}</p>
+    <p>Published: {{ page.date | date: "%b %-d, %Y" }}{% if page.author %} by {{ page.author }}{% endif %}</p>
 
     {{ content }}
 </div>

--- a/_sass/_layout.scss
+++ b/_sass/_layout.scss
@@ -12,7 +12,7 @@ div.highlight {
     }
 }
 
-.contents {
+div > div.contents {
     box-shadow: $box-shadow;
     padding: 1.5rem;
     margin-bottom: 3rem;
@@ -20,4 +20,10 @@ div.highlight {
 
 .hero-darken {
     background-color: rgba($hero-darken, 0.5);
+}
+
+aside.sticky {
+  position: -webkit-sticky; /* Safari */
+  position: sticky;
+  top: 20px;
 }

--- a/assets/js/stickytoc.js
+++ b/assets/js/stickytoc.js
@@ -1,0 +1,25 @@
+function attachStickyMenuObserver(min, max) {
+    const headers = [...Array(max-min + 1).keys()].map(i=>`h${i+min}[id]`);
+    window.addEventListener('DOMContentLoaded', () => {
+        const observer = new IntersectionObserver(_ => {
+            document.querySelectorAll(`div.contents li > a.is-active`).forEach(e => {
+                e.classList.remove`is-active`;
+            });
+            var candidate = null;
+            [...document.querySelectorAll(headers)].every(e => {
+                const r = e.getBoundingClientRect();
+                if (!candidate || r.top < (window.innerHeight || document.documentElement.clientHeight)) {
+                    candidate = e;
+                }
+                return r.bottom <= 0;
+            });
+            if (candidate) {
+                const id = candidate.getAttribute('id');
+                document.querySelector(`div.contents li > a[href="#${id}"]`).classList.add`is-active`;
+            }
+        });
+        document.querySelectorAll(headers).forEach(e => {
+            observer.observe(e);
+        });
+    });
+}


### PR DESCRIPTION
Hello,

I have just been creating a site with this theme and made a couple tweaks to the table of contents functionality that I think would be nice to have included in the main source.

1. Move TOC support from `page` to `default` layout. This is so its possible to have a TOC on long blog posts.
2. Parameterise the min and max levels of the TOC, so the `toc_min: n` and `toc_max: m` can be provided in either the pages frontmatter or the `_config.yml` to apply to whole site. The default values are preserved as 2 and 3, respectively.
3. Modify `menubar` layout to optionally source its data from the TOC instead of a yml file. This is enabled by setting both `menubar: true` and `toc: menubar`.
4. Allow for the `menubar` to be defined as sticky, i.e. it scrolls with the page. This is done with `menubar_sticky: true` option.
5. Added support for the current TOC link to be highlighted depending on what is being viewed. This is done with including a JavaScript function. To enable this, it will be automatically enabled when 3 and 4 are both enabled. That is, its possible to have the TOC scroll with the window and and highlight the current header depending which section is being viewed.

Below are a couple screen shots of the changes reflecting point 5:

![image](https://user-images.githubusercontent.com/527411/94360157-52938180-00a3-11eb-99b8-456475c56323.png)

And again, when scrolled lower down:
![image](https://user-images.githubusercontent.com/527411/94360142-40b1de80-00a3-11eb-8c4c-ed1b761e2e7e.png)


Finally, I included a small patch in this PR that removes a dangling "by" in the `post` layout when the `page.author` is not defined.

I am not much of a front end developer, so maybe there were better ways of doing the above. However, I have tested in Chrome and on my phone and the changes appear to work well :wink: Comments/suggestions welcome.