### PR TITLE
Added theme color meta tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,10 @@ $primary: #333333;
 
 You can overwrite any of the [Bulma initial variables](http://versions.bulma.io/0.7.0/documentation/overview/variables/) in this way as long as they are declared before the `@import "main"'`
 
+#### Theme Color Meta Tag
+
+If you want to update the theme color meta tag then set `theme_color: '#333333'` in your `_config.yml` file. 
+
 ### Sidebar Visibility
 
 **New in 0.2**

--- a/_config.yml
+++ b/_config.yml
@@ -10,6 +10,7 @@ permalink: pretty
 #favicon: /path/to/favicon.png
 gh_sponsor: chrisrhymes
 #hide_share_buttons: true
+#theme_color: '#eeeeee'
 
 paginate: 5
 paginate_path: "/blog/page:num"

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -1,6 +1,7 @@
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="theme-color" content={{ site.theme_color | default: '#ffffff' }}>
     <title>{{ page.title }} - {{ site.title }}</title>
     <link rel="stylesheet" href="{{ site.baseurl }}/assets/css/app.css">
     <link rel="shortcut icon" type="image/png"


### PR DESCRIPTION
Resolves issue #71 

The default is set to '#ffffff' and can be overridden in the site's `_config.yml` file if needed.