### PR TITLE
Allow contents in menubar location

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,9 @@ If you would like to darken the hero so the title stands out more, you can set `
 **New in 0.5.8**
 If you want to display a table of contents (toc) then add `toc: true` to your page's front matter. You can customise the default table of contents title by setting `toc_title: My Custom Title` in the page's front matter. 
 
+**New in 0.10.3**
+If you would prefer to display the contents in the menubar at the side of the page, then use `menubar_toc: true` instead of `toc: true`. This will also override the page's `menubar` setting.
+
 ### Posts
 
 If you want posts, create a `_posts` directory to store your posts as per normal Jekyll usage, with the `layout: post`. Next create a `blog` directory with an index.html file that has `layout: blog`

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -17,7 +17,12 @@
     <section class="section">
         <div class="container">
             <div class="columns">
-                {% if page.menubar %}
+                {% if page.menubar_toc %}
+                <div class="column is-4-desktop is-4-tablet">
+                    {% assign contentsTitle = page.toc_title | default: 'Contents' %}
+                    {% include toc.html html=content class='menu-list' h_min=2 h_max=3 contents_title=contentsTitle %}
+                </div>
+                {% elsif page.menubar %}
                 <div class="column is-4-desktop is-4-tablet">
                     {% include menubar.html %}
                 </div>

--- a/bulma-clean-theme.gemspec
+++ b/bulma-clean-theme.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name          = "bulma-clean-theme"
-  spec.version       = "0.10.2"
+  spec.version       = "0.10.3"
   spec.authors       = ["chrisrhymes"]
   spec.email         = ["csrhymes@gmail.com"]
 

--- a/page-with-contents.md
+++ b/page-with-contents.md
@@ -30,3 +30,14 @@ title: Page With Contents
 toc: true
 toc_title: Custom Title
 ```
+
+## Displaying the contents in the menubar
+
+If you would prefer to display the contents in the menubar at the side of the page, then use `menubar_toc: true` instead of `toc: true`. This will also override the page's `menubar` setting.
+
+```yaml
+layout: page
+title: Page With Contents
+menubar_toc: true
+toc_title: Custom Title
+```


### PR DESCRIPTION
This is inspired by #57 by @kazkansouh but is a simplified implementation. 

This allows the contents to be where the menubar is normally by setting `menubar_toc: true` in the page's front matter instead of `toc: true`. 

