### PR TITLE
Fix content width when menubar_toc is enabled

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,6 +1,6 @@
-{% if page.menubar and page.show_sidebar %} 
+{% if (page.menubar or page.menubar_toc) and page.show_sidebar %} 
     {% assign content_width = 'is-4' %} 
-{% elsif page.menubar or page.show_sidebar %} 
+{% elsif (page.menubar or page.menubar_toc) or page.show_sidebar %} 
     {% assign content_width = 'is-8' %} 
 {% else %} 
     {% assign content_width = 'is-12' %} 

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,10 +1,15 @@
-{% if (page.menubar or page.menubar_toc) and page.show_sidebar %} 
+{% if page.menubar or page.menubar_toc %}
+    {% assign has_left_sidebar = true %}
+{% endif %}
+
+{% if page.show_sidebar and has_left_sidebar  %} 
     {% assign content_width = 'is-4' %} 
-{% elsif (page.menubar or page.menubar_toc) or page.show_sidebar %} 
+{% elsif page.show_sidebar or has_left_sidebar %} 
     {% assign content_width = 'is-8' %} 
 {% else %} 
     {% assign content_width = 'is-12' %} 
 {% endif %}
+
 <!DOCTYPE html>
 <html {% if site.fixed_navbar %} class="has-navbar-fixed-{{ site.fixed_navbar }}" {% endif %}>
   {% include head.html %}


### PR DESCRIPTION
While `menubar_toc` is active, the content width is still set as `is-12`. This should fix the issue.