### PR TITLE
README should say remote_theme instead of theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ gem "bulma-clean-theme"
 And add this line to your Jekyll site's `_config.yml`:
 
 ```yaml
-theme: bulma-clean-theme
+remote_theme: bulma-clean-theme
 ```
 
 And then execute:


### PR DESCRIPTION
GitHub pages wasn't correctly building for me when trying to use this template, the following error was showing:
```
GitHub Pages failed to build your site.
A file was included in /_layouts/post.html that is a symlink or does not exist in your _includes directory.
```
found out that changing said property in _config.yaml fixed the error; this also aligns with what is said in https://www.csrhymes.com/bulma-clean-theme/.