### PR TITLE
Allow Jekyll v4 while keeping the theme compatible with the GitHub Pages gem

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,6 @@ The theme uses [Alpine.js](https://github.com/alpinejs/alpine) for its interacti
 
 ## Installation
 
-**This theme requires Jekyll 3.9 to be compatible with GitHub Pages.**
-
 Add this line to your Jekyll site's `Gemfile`:
 
 ```ruby
@@ -63,6 +61,8 @@ If you are deploying to GitHub pages, then you can also install the [GitHub Page
 # With GitHub Pages Gem
 remote_theme: chrisrhymes/bulma-clean-theme
 ```
+
+**Note that the GitHub Pages gem requires Jekyll version 3.9.**
 
 And then execute:
 

--- a/README.md
+++ b/README.md
@@ -55,14 +55,12 @@ And add this line to your Jekyll site's `_config.yml`:
 theme: bulma-clean-theme
 ```
 
-If you are deploying to GitHub pages, then you can also install the [GitHub Pages gem](https://github.com/github/pages-gem) and use `remote_theme` instead of `theme` in your `_config.yml`.
+If you are deploying to GitHub pages, then you can also install the [GitHub Pages gem](https://github.com/github/pages-gem) and use `remote_theme` instead of `theme` in your `_config.yml`. **Note that the GitHub Pages gem requires Jekyll version 3.9.**
 
 ```yaml
 # With GitHub Pages Gem
 remote_theme: chrisrhymes/bulma-clean-theme
 ```
-
-**Note that the GitHub Pages gem requires Jekyll version 3.9.**
 
 And then execute:
 

--- a/bulma-clean-theme.gemspec
+++ b/bulma-clean-theme.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
 
   spec.files         = `git ls-files -z`.split("\x0").select { |f| f.match(%r!^(assets|_layouts|_includes|_sass|_posts|blog|LICENSE|README|package|node_modules|favicon)!i) }
 
-  spec.add_runtime_dependency "jekyll", "~> 3.9"
+  spec.add_runtime_dependency "jekyll", ">= 3.9", "< 4.3"
   spec.add_runtime_dependency "jekyll-feed", "~> 0.15"
   spec.add_runtime_dependency "jekyll-sitemap", "~> 1.4"
   spec.add_runtime_dependency "jekyll-paginate", "~> 1.1"


### PR DESCRIPTION
This PR updates the dependency range for Jekyll such that the theme can be used with both the latest version of Jekyll (4.2), as well as the version compatible with the GitHub Pages gem (3.9).

The reason I am suggesting this change is that I want to use this theme for a new Jekyll site that I am **not** deploying using the GitHub Pages gem, and I would like to have that site start on a newer version of Jekyll since the sass dependency in Jekyll v3.9 is end of life, and in general I would much prefer starting a new project with latest versions for maintainability and access to new features, etc. Also, see the comment I left in issue [#26](https://github.com/chrisrhymes/bulma-clean-theme/issues/26#issuecomment-1032135272).

Testing:
- To test that this theme works with Jekyll v4, I installed the project dependencies from my local checkout of this branch (`bundle install`) and then ran the hot reload server (`bundle exec jekyll serve`). Jekyll version `4.2.1` was installed and the site built and ran as I would expect.
- To test that this branch still works with the GitHub Pages gem, I created a [repository with a simple jekyll site](https://github.com/eheinrich/hello-world-jekyll) and set the [`remote_theme` configuration to point it at this branch](https://github.com/eheinrich/hello-world-jekyll/blob/main/_config.yml#L1). Jekyll version 3.9 was used to build the site and it works as expected - can see the site [here](https://eheinrich.github.io/hello-world-jekyll/).

Thank you for considering!