### PR TITLE
Added jekyll-feed meta to page head include

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -12,6 +12,9 @@
         <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bulma-social@1/bin/bulma-social.min.css">
     {% endunless %}
     {% seo %}
+    {% if site.feed %}
+    {% feed_meta %}
+    {% endif %}
     {%- if site.google_analytics -%}
       {%- include google-analytics.html -%}
     {%- endif -%}


### PR DESCRIPTION
Includes the meta tag for the jekyll-feed plugin, if its config is present.