### PR TITLE
Fix image modal by replacing alpine.js shorthand syntax

### DIFF
--- a/_includes/image-modal.html
+++ b/_includes/image-modal.html
@@ -1,11 +1,11 @@
-<div x-data="{ open: false }">
-    <a @click="open = true" title="View large image">
+<div x-data="{ open: false }" markdown="0">
+    <a x-on:click="open = true" title="View large image">
         <figure class="image {{ include.ratio | default: is-16by9 }}">
             <img src="{{ include.link | absolute_url }}" alt="{{ include.alt }}">
         </figure>
     </a>
-    <div class="modal" :class="{ 'is-active': open }">
-        <div class="modal-background" @click="open = false"></div>
+    <div class="modal" x-bind:class="open ? 'is-active' : ''" x-cloak>
+        <div class="modal-background" x-on:click="open = false"></div>
         <div class="modal-content">
             {% if include.large_link %}
                 <img src="{{ include.large_link | absolute_url }}" alt="{{ include.alt }}">
@@ -13,6 +13,6 @@
                 <img src="{{ include.link | absolute_url }}" alt="{{ include.alt }}">
             {% endif %}
         </div>
-        <button class="modal-close is-large" aria-label="close" @click="open = false"></button>
+        <button class="modal-close is-large" aria-label="close" x-on:click="open = false"></button>
     </div>
 </div>

--- a/_sass/_layout.scss
+++ b/_sass/_layout.scss
@@ -35,3 +35,6 @@ div.highlight {
         margin-bottom: 0.75rem;
     }
 }
+
+// Alpine.js hide on initial load
+[x-cloak] { display: none !important; }

--- a/docs/page-components/image-modal.md
+++ b/docs/page-components/image-modal.md
@@ -24,3 +24,14 @@ Below is an example for the include.
 {% include image-modal.html ratio="is-16by9" link="https://via.placeholder.com/400x225" alt="Example image" large_link="https://via.placeholder.com/1200x675" %}
 </code>
 {% endraw %}
+
+## Example Image Modal
+
+<div class="columns">
+<div class="column is-6">
+{% include image-modal.html ratio="is-16by9" link="https://via.placeholder.com/400x225" alt="Example image" large_link="https://via.placeholder.com/1200x675" %}
+</div>
+<div class="column is-6">
+Click on the image to open the image modal.
+</div>
+</div>


### PR DESCRIPTION
- Replace the alpine js shorthand `@click` with `x-on:click` and `:class` with `x-bind:class`
- Add x-cloak to hide the modal on initial render
- Add example to the image modal docs page