### PR TITLE
Fix remote_theme docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ If you are deploying to GitHub pages using their default build process, then you
 
 ```yaml
 # With GitHub Pages Gem
-remote_theme: chrisrhymes/bulma-clean-theme:v0.14.0
+remote_theme: chrisrhymes/bulma-clean-theme@v0.14.0
 ```
 
 ## Documentation

--- a/_posts/2019-02-09-getting-started-with-bulma-clean-theme.markdown
+++ b/_posts/2019-02-09-getting-started-with-bulma-clean-theme.markdown
@@ -128,7 +128,7 @@ For the site to work with Github Pages, all you need to do is update the _config
 
 ```yaml
 #theme: bulma-clean-theme
-remote_theme: chrisrhymes/bulma-clean-theme
+remote_theme: chrisrhymes/bulma-clean-theme@v0.14.0
 ```
 
 And then push up your changes to Github as normal. 

--- a/_posts/2020-05-08-creating-a-docs-site-with-bulma-clean-theme.markdown
+++ b/_posts/2020-05-08-creating-a-docs-site-with-bulma-clean-theme.markdown
@@ -42,10 +42,10 @@ gem "bulma-clean-theme",  '0.7.2'
 gem 'github-pages', group: :jekyll_plugins
 ```
 
-2. Open the `_config.yml` and comment out or delete the line `theme: minima` and replace it with `remote_theme: chrisrhymes/bulma-clean-theme`, then add `github-pages` to the list of plugins. Update the baseurl to your GitHub repo name, in this example we are using `my-project` as the repo name
+2. Open the `_config.yml` and comment out or delete the line `theme: minima` and replace it with `remote_theme: chrisrhymes/bulma-clean-theme@v0.14.0`, then add `github-pages` to the list of plugins. Update the baseurl to your GitHub repo name, in this example we are using `my-project` as the repo name
 ```yaml
 #theme: minima
-remote_theme: chrisrhymes/bulma-clean-theme
+remote_theme: chrisrhymes/bulma-clean-theme@v0.14.0
 baseurl: "/my-project"
 plugins:
 - github-pages

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -41,7 +41,7 @@ Ensure you specify the version number at the end of the remote_theme, otherwise 
 
 ```yaml
 # _config.yml
-remote_theme: chrisrhymes/bulma-clean-theme:v0.14.0
+remote_theme: chrisrhymes/bulma-clean-theme@v0.14.0
 ```
 
 ### v1.x of Bulma Clean Theme

--- a/docs/getting-started/upgrading-to-v1.md
+++ b/docs/getting-started/upgrading-to-v1.md
@@ -32,7 +32,7 @@ If you are using Jekyll Remote Theme, then you can [add a version number](https:
 
 ```yaml
 # _config.yml
-remote_theme: chrisrhymes/bulma-clean-theme:v1.0.0
+remote_theme: chrisrhymes/bulma-clean-theme@v1.0.0
 ```
 
 ## Changes to Bulma

--- a/index.md
+++ b/index.md
@@ -18,14 +18,6 @@ This website showcases the options for the Bulma Clean theme. The theme is avail
 
 The ruby gem is available on the Ruby Gems website at the following location. [https://rubygems.org/gems/bulma-clean-theme](https://rubygems.org/gems/bulma-clean-theme).
 
-## GitHub Pages
-
-The theme can be used with GitHub Pages by setting the `remote_theme` in your Jekyll sites `_config.yml`
-
-```yml
-remote_theme: chrisrhymes/bulma-clean-theme
-```
-
 ## Documentation
 
 For full instructions, please see the [Documentation](/bulma-clean-theme/docs/)


### PR DESCRIPTION
Resolves #154 

Update references for remote_theme to use `@` as per the remote_theme gem documentation. 