### PR TITLE
Set default consent as granted if cookies accepted

### DIFF
--- a/_includes/cookie-banner.html
+++ b/_includes/cookie-banner.html
@@ -1,8 +1,4 @@
 <div class="">
-    <script
-        src="https://cdn.jsdelivr.net/npm/js-cookie@3.0.5/dist/js.cookie.min.js"
-    ></script>
-
     <div class="container py-6 px-4" id="cookieBanner">
         <div class="columns">
             <div class="column is-fullwidth ">

--- a/_includes/google-analytics.html
+++ b/_includes/google-analytics.html
@@ -5,14 +5,23 @@
         dataLayer.push(arguments);
     }
 
-    // Set default consent to 'denied' as a placeholder
-    // Determine actual values based on your own requirements
-    gtag('consent', 'default', {
-        ad_storage: 'denied',
-        ad_user_data: 'denied',
-        ad_personalization: 'denied',
-        analytics_storage: 'denied',
-    });
+    // Set default consent to 'denied' as a placeholder unless already accepted
+    var cookiesAccepted = Cookies.get('cookiesAccepted');
+    if (cookiesAccepted === 'true') {
+        gtag('consent', 'default', {
+            ad_storage: 'granted',
+            ad_user_data: 'granted',
+            ad_personalization: 'granted',
+            analytics_storage: 'granted',
+        });
+    } else {
+        gtag('consent', 'default', {
+            ad_storage: 'denied',
+            ad_user_data: 'denied',
+            ad_personalization: 'denied',
+            analytics_storage: 'denied',
+        });
+    }
 </script>
 <!-- Google tag (gtag.js) -->
 <script async src="https://www.googletagmanager.com/gtag/js?id={{ site.google_analytics }}"></script>

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -13,6 +13,9 @@
         {% endif %}
     >
     <script defer src="https://unpkg.com/alpinejs@3.9.0/dist/cdn.min.js"></script>
+    <script
+        src="https://cdn.jsdelivr.net/npm/js-cookie@3.0.5/dist/js.cookie.min.js"
+    ></script>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@5/css/all.min.css">
     {% unless site.hide_share_buttons %}
         <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bulma-social@1/bin/bulma-social.min.css">

--- a/bulma-clean-theme.gemspec
+++ b/bulma-clean-theme.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name          = "bulma-clean-theme"
-  spec.version       = "1.0.1"
+  spec.version       = "1.0.2"
   spec.authors       = ["chrisrhymes"]
   spec.email         = ["csrhymes@gmail.com"]
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,6 @@
+# 1.0.2
+* Update Google Analytics to set default as 'granted' when cookies are already accepted
+
 # 1.0.1
 * Fix auto dark mode and allow forcing a theme
 


### PR DESCRIPTION
Update Google Analytics script to set default consent as granted if cookies are already accepted. 