### PR TITLE
Allow custom collection name for products

### DIFF
--- a/_includes/cookie-banner.html
+++ b/_includes/cookie-banner.html
@@ -23,13 +23,13 @@
             {% if site.google_analytics %}
                 consentGrantedAdStorage();
             {% endif %}
-            Cookies.set('showCookieBanner', 'false', { expires: 7, path: '/' });
-            Cookies.set('cookiesAccepted', 'true', {expires: 7, path: '/'});
+            Cookies.set('showCookieBanner', 'false', { expires: 365, path: '/' });
+            Cookies.set('cookiesAccepted', 'true', {expires: 365, path: '/'});
             toggleCookieBanner();
         }
 
         function rejectCookies() {
-            Cookies.set('showCookieBanner', 'false', { expires: 7, path: '/' });
+            Cookies.set('showCookieBanner', 'false', { expires: 365, path: '/' });
             toggleCookieBanner();
         }
 

--- a/_layouts/product-category.html
+++ b/_layouts/product-category.html
@@ -7,7 +7,11 @@ show_sidebar: false
         {{ page.content }}
     </div>
 
-    {% assign sorted_products = site.products | sort: page.sort %}
+    {% if page.collection %}
+        {% assign sorted_products = site.[page.collection] | sort: page.sort %}
+    {% else %}
+        {% assign sorted_products = site.products | sort: page.sort %}
+    {% endif %}
 
     {% for product in sorted_products %}
         <div class="column is-4-desktop is-6-tablet">

--- a/docs/products/category-page.md
+++ b/docs/products/category-page.md
@@ -22,3 +22,18 @@ sort: title
 ```
 
 [View example Category page](/bulma-clean-theme/products/)
+
+## Customising the collection
+
+To use a different collection than `products`, set the collection name in the category page's front matter. 
+
+The below example uses a collection called `books`. 
+
+```yaml
+title: Books
+subtitle: Check out our range of books
+layout: product-category
+show_sidebar: false
+sort: title
+collection: books
+```

--- a/docs/products/product-pages.md
+++ b/docs/products/product-pages.md
@@ -9,7 +9,11 @@ toc: true
 
 ## Products Directory
 
-Start by creating a `_products` directory to hold your product pages.
+The default collection name for products is `products`, so create a `_products` directory to hold your product pages.
+
+## Custom Collection Directory
+
+You can override the default and create a folder with your own collection name. For example, using a collection of `books` would require you to create a folder called `_books`.
 
 ## Product Pages
 
@@ -52,3 +56,7 @@ collections:
 ```
 
 You can also set default product page values here if you like, such as the layout or image. 
+
+{% include notification.html message="If you use a custom collection name then update `products` to your custom collection name. In the example above for the `_books` folder use `books` as the collection name." %}
+
+For more information on collections, please refer to the [Jekyll documentation](https://jekyllrb.com/docs/collections/). 


### PR DESCRIPTION
- Allow using a custom collection name for products, but defaults to 'products'.
- Update the cookie expiry time to 365 days to prevent return visitors having to keep accepting/rejecting cookies.
- Update the docs for the product pages