### PR TITLE
fix rake and sass-embedded versions to successfuly deploy on github a…

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,4 +10,5 @@ group :jekyll_plugins do
     gem "jekyll-seo-tag"
     gem 'jekyll-redirect-from'
 end
+gem 'sass-embedded', '~> 1.83'
 

--- a/bulma-clean-theme.gemspec
+++ b/bulma-clean-theme.gemspec
@@ -20,5 +20,5 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "kramdown-parser-gfm", "~> 1.1"
 
   spec.add_development_dependency "bundler", "~> 2.0"
-  spec.add_development_dependency "rake", "~> 12.0"
+  spec.add_development_dependency "rake", "~> 13.0"
 end


### PR DESCRIPTION
fixes #171 

when deploying to GitHub actions, there is an incompatibility between older versions of ruby and sass-embedded.
Given that you are using the latest version of ruby you will need newer versions of rake and sass embedded. This fix the disruption of versions between dependencies.