### PR TITLE
Add Buy it button to product layout with custom icon support

### DIFF
--- a/_layouts/product.html
+++ b/_layouts/product.html
@@ -41,16 +41,16 @@ layout: default
             <div class="is-flex is-justify-content-flex-end mt-4">
                 <div class="buttons">
                     {% for button in page.buttons %}
-                        {% if button.icon %}
-                            <a href="{{ button.url }}" {% if button.class %}class="{{ button.class }}"{% endif %}>
-                                <img src="{{ button.icon }}" alt="{{ button.text | default: 'Buy it' }}" style="max-height: 60px;">
+                        {% if button.image %}
+                            <a href="{{ button.url }}" {% if button.class %} class="{{ button.class }}" {% endif %}>
+                                <img src="{{ button.image }}" alt="{{ button.text | default: 'Buy it' }}" style="max-height: 60px;">
                                 <span class="is-sr-only">{{ button.text | default: 'Buy it' }}</span>
                             </a>
                         {% else %}
-                            <a href="{{ button.url }}" class="button {% if button.class %}{{ button.class }}{% else %}is-primary{% endif %} is-medium">
-                                {% if button.icon_class %}
+                            <a href="{{ button.url }}" class="button {% if button.class %} {{ button.class }} {% else %} is-primary {% endif %} is-medium">
+                                {% if button.icon %}
                                     <span class="icon">
-                                        <i class="{{ button.icon_class }}"></i>
+                                        <i class="fas {{ button.icon }}"></i>
                                     </span>
                                 {% endif %}
                                 <span>{{ button.text | default: 'Buy it' }}</span>

--- a/_layouts/product.html
+++ b/_layouts/product.html
@@ -38,21 +38,20 @@ layout: default
         {% endif %}
 
         {% if page.shop_url %}
-            <div class="field is-grouped has-text-right">
-                <div class="control">
-                    {% if page.shop_icon %}
-                        <a href="{{ page.shop_url }}" target="_blank">
-                            <img src="{{ page.shop_icon }}" alt="Buy it" style="max-height: 60px;">
-                        </a>
-                    {% else %}
-                        <a href="{{ page.shop_url }}" class="button is-primary is-medium" target="_blank">
-                            <span class="icon">
-                                <i class="fas fa-shopping-cart"></i>
-                            </span>
-                            <span>Buy it</span>
-                        </a>
-                    {% endif %}
-                </div>
+            <div class="is-flex is-justify-content-flex-end mt-4">
+                {% if page.shop_icon %}
+                    <a href="{{ page.shop_url }}">
+                        <img src="{{ page.shop_icon }}" alt="{{ page.shop_button_text | default: 'Buy it' }}" style="max-height: 60px;">
+                        <span class="is-sr-only">{{ page.shop_button_text | default: 'Buy it' }}</span>
+                    </a>
+                {% else %}
+                    <a href="{{ page.shop_url }}" class="button is-primary is-medium">
+                        <span class="icon">
+                            <i class="fas fa-shopping-cart"></i>
+                        </span>
+                        <span>{{ page.shop_button_text | default: 'Buy it' }}</span>
+                    </a>
+                {% endif %}
             </div>
         {% endif %}
     </div>

--- a/_layouts/product.html
+++ b/_layouts/product.html
@@ -37,21 +37,27 @@ layout: default
             </div>
         {% endif %}
 
-        {% if page.shop_url %}
+        {% if page.buttons %}
             <div class="is-flex is-justify-content-flex-end mt-4">
-                {% if page.shop_icon %}
-                    <a href="{{ page.shop_url }}">
-                        <img src="{{ page.shop_icon }}" alt="{{ page.shop_button_text | default: 'Buy it' }}" style="max-height: 60px;">
-                        <span class="is-sr-only">{{ page.shop_button_text | default: 'Buy it' }}</span>
-                    </a>
-                {% else %}
-                    <a href="{{ page.shop_url }}" class="button is-primary is-medium">
-                        <span class="icon">
-                            <i class="fas fa-shopping-cart"></i>
-                        </span>
-                        <span>{{ page.shop_button_text | default: 'Buy it' }}</span>
-                    </a>
-                {% endif %}
+                <div class="buttons">
+                    {% for button in page.buttons %}
+                        {% if button.icon %}
+                            <a href="{{ button.url }}" {% if button.class %}class="{{ button.class }}"{% endif %}>
+                                <img src="{{ button.icon }}" alt="{{ button.text | default: 'Buy it' }}" style="max-height: 60px;">
+                                <span class="is-sr-only">{{ button.text | default: 'Buy it' }}</span>
+                            </a>
+                        {% else %}
+                            <a href="{{ button.url }}" class="button {% if button.class %}{{ button.class }}{% else %}is-primary{% endif %} is-medium">
+                                {% if button.icon_class %}
+                                    <span class="icon">
+                                        <i class="{{ button.icon_class }}"></i>
+                                    </span>
+                                {% endif %}
+                                <span>{{ button.text | default: 'Buy it' }}</span>
+                            </a>
+                        {% endif %}
+                    {% endfor %}
+                </div>
             </div>
         {% endif %}
     </div>

--- a/_layouts/product.html
+++ b/_layouts/product.html
@@ -38,7 +38,7 @@ layout: default
         {% endif %}
 
         {% if page.shop_url %}
-            <div class="field is-grouped">
+            <div class="field is-grouped has-text-right">
                 <div class="control">
                     {% if page.shop_icon %}
                         <a href="{{ page.shop_url }}" target="_blank">

--- a/_layouts/product.html
+++ b/_layouts/product.html
@@ -36,6 +36,25 @@ layout: default
                 {% endfor %}
             </div>
         {% endif %}
+
+        {% if page.shop_url %}
+            <div class="field is-grouped">
+                <div class="control">
+                    {% if page.shop_icon %}
+                        <a href="{{ page.shop_url }}" target="_blank">
+                            <img src="{{ page.shop_icon }}" alt="Buy it" style="max-height: 60px;">
+                        </a>
+                    {% else %}
+                        <a href="{{ page.shop_url }}" class="button is-primary is-medium" target="_blank">
+                            <span class="icon">
+                                <i class="fas fa-shopping-cart"></i>
+                            </span>
+                            <span>Buy it</span>
+                        </a>
+                    {% endif %}
+                </div>
+            </div>
+        {% endif %}
     </div>
 
     <div class="column is-12">

--- a/_products/product1.md
+++ b/_products/product1.md
@@ -15,10 +15,10 @@ features:
       icon: fa-fighter-jet
 rating: 3
 buttons:
-    - url: https://example-shop.com/product/ABC124
+    - url: https://example.com/product/ABC124
       text: Buy it now
       class: is-primary
-      icon_class: fas fa-shopping-cart
+      icon: fa-shopping-cart
 ---
 
 This is the content about the product.

--- a/_products/product1.md
+++ b/_products/product1.md
@@ -14,6 +14,11 @@ features:
     - label: Available in multiple sizes
       icon: fa-fighter-jet
 rating: 3
+buttons:
+    - url: https://example-shop.com/product/ABC124
+      text: Buy it now
+      class: is-primary
+      icon_class: fas fa-shopping-cart
 ---
 
 This is the content about the product.

--- a/docs/products/product-pages.md
+++ b/docs/products/product-pages.md
@@ -38,35 +38,48 @@ features:
     - label: Available in multiple sizes
       icon: fa-fighter-jet
 rating: 3
-shop_url: https://example-shop.com/product/ABC124
-shop_icon: https://example.com/custom-button.png
+buttons:
+    - url: https://example-shop.com/product/ABC124
+      text: Buy on Amazon
+      class: is-primary
+      icon_class: fas fa-shopping-cart
+    - url: https://ebay.com/item/123
+      text: Buy on eBay
+      class: is-link
 ```
 
 The text you write for the page content will be displayed as the product description. 
 
-### Buy it Button
+### Buttons
 
-You can add a "Buy it" button to your product pages by including the following optional fields in your product's front matter:
+You can add one or more buttons to your product pages by including the `buttons` array in your product's front matter. Each button can have the following properties:
 
-- `shop_url`: (Required) The URL to your e-shop or product purchase page
-- `shop_icon`: (Optional) HTTP link to a custom PNG image for the button
-- `shop_button_text`: (Optional) Custom text for the button (defaults to "Buy it")
+- `url`: (Required) The URL to your e-shop or product purchase page
+- `text`: (Optional) Button text (defaults to "Buy it")
+- `class`: (Optional) Bulma button class for styling (e.g., `is-primary`, `is-link`, `is-success`)
+- `icon_class`: (Optional) Font Awesome icon class (e.g., `fas fa-shopping-cart`)
+- `icon`: (Optional) HTTP link to a custom PNG image for the button (displays image instead of button)
 
-If `shop_icon` is provided, the button will display your custom image. If not provided, a standard blue Bulma button with shopping cart icon and customizable text will be displayed.
+Buttons are displayed side by side, right-aligned, and appear below the product features section.
 
-The button is right-aligned and appears below the product features section.
-
-**Example with custom button image:**
+**Example with multiple standard buttons:**
 ```yaml
-shop_url: https://example-shop.com/product/ABC124
-shop_icon: https://example.com/custom-button.png
-shop_button_text: Buy on eBay
+buttons:
+    - url: https://example-shop.com/product/ABC124
+      text: Buy on Amazon
+      class: is-primary
+      icon_class: fas fa-shopping-cart
+    - url: https://ebay.com/item/123
+      text: Buy on eBay
+      class: is-link
 ```
 
-**Example with standard button:**
+**Example with custom icon image:**
 ```yaml
-shop_url: https://example-shop.com/product/ABC124
-shop_button_text: Buy on Amazon
+buttons:
+    - url: https://example-shop.com/product/ABC124
+      icon: https://example.com/custom-button.png
+      text: Buy it
 ```
 
 [View example Product page](/bulma-clean-theme/products/product2/)

--- a/docs/products/product-pages.md
+++ b/docs/products/product-pages.md
@@ -50,20 +50,23 @@ You can add a "Buy it" button to your product pages by including the following o
 
 - `shop_url`: (Required) The URL to your e-shop or product purchase page
 - `shop_icon`: (Optional) HTTP link to a custom PNG image for the button
+- `shop_button_text`: (Optional) Custom text for the button (defaults to "Buy it")
 
-If `shop_icon` is provided, the button will display your custom image. If not provided, a standard blue Bulma button with shopping cart icon and "Buy it" text will be displayed.
+If `shop_icon` is provided, the button will display your custom image. If not provided, a standard blue Bulma button with shopping cart icon and customizable text will be displayed.
 
-The button is right-aligned and appears below the product features section. All links open in a new window.
+The button is right-aligned and appears below the product features section.
 
 **Example with custom button image:**
 ```yaml
 shop_url: https://example-shop.com/product/ABC124
 shop_icon: https://example.com/custom-button.png
+shop_button_text: Buy on eBay
 ```
 
 **Example with standard button:**
 ```yaml
 shop_url: https://example-shop.com/product/ABC124
+shop_button_text: Buy on Amazon
 ```
 
 [View example Product page](/bulma-clean-theme/products/product2/)

--- a/docs/products/product-pages.md
+++ b/docs/products/product-pages.md
@@ -39,11 +39,11 @@ features:
       icon: fa-fighter-jet
 rating: 3
 buttons:
-    - url: https://example-shop.com/product/ABC124
+    - url: https://example.com/product/ABC124
       text: Buy on Amazon
       class: is-primary
-      icon_class: fas fa-shopping-cart
-    - url: https://ebay.com/item/123
+      icon: fa-shopping-cart
+    - url: https://example.com/item/123
       text: Buy on eBay
       class: is-link
 ```
@@ -57,19 +57,19 @@ You can add one or more buttons to your product pages by including the `buttons`
 - `url`: (Required) The URL to your e-shop or product purchase page
 - `text`: (Optional) Button text (defaults to "Buy it")
 - `class`: (Optional) Bulma button class for styling (e.g., `is-primary`, `is-link`, `is-success`)
-- `icon_class`: (Optional) Font Awesome icon class (e.g., `fas fa-shopping-cart`)
-- `icon`: (Optional) HTTP link to a custom PNG image for the button (displays image instead of button)
+- `icon`: (Optional) Font Awesome icon class (e.g., `fa-shopping-cart`)
+- `image`: (Optional) HTTP link to a custom PNG image for the button (displays image instead of button)
 
 Buttons are displayed side by side, right-aligned, and appear below the product features section.
 
 **Example with multiple standard buttons:**
 ```yaml
 buttons:
-    - url: https://example-shop.com/product/ABC124
+    - url: https://example.com/product/ABC124
       text: Buy on Amazon
       class: is-primary
-      icon_class: fas fa-shopping-cart
-    - url: https://ebay.com/item/123
+      icon: fa-shopping-cart
+    - url: https://example.com/item/123
       text: Buy on eBay
       class: is-link
 ```
@@ -77,8 +77,8 @@ buttons:
 **Example with custom icon image:**
 ```yaml
 buttons:
-    - url: https://example-shop.com/product/ABC124
-      icon: https://example.com/custom-button.png
+    - url: https://example.com/product/ABC124
+      image: https://example.com/custom-button.png
       text: Buy it
 ```
 
@@ -93,7 +93,7 @@ collections:
   products: 
     output: true
     layout: product
-    image: https://via.placeholder.com/800x600
+    image: https://picsum.photos/id/10/600/480
     show_sidebar: false
 ```
 

--- a/docs/products/product-pages.md
+++ b/docs/products/product-pages.md
@@ -38,9 +38,33 @@ features:
     - label: Available in multiple sizes
       icon: fa-fighter-jet
 rating: 3
+shop_url: https://example-shop.com/product/ABC124
+shop_icon: https://example.com/custom-button.png
 ```
 
 The text you write for the page content will be displayed as the product description. 
+
+### Buy it Button
+
+You can add a "Buy it" button to your product pages by including the following optional fields in your product's front matter:
+
+- `shop_url`: (Required) The URL to your e-shop or product purchase page
+- `shop_icon`: (Optional) HTTP link to a custom PNG image for the button
+
+If `shop_icon` is provided, the button will display your custom image. If not provided, a standard blue Bulma button with shopping cart icon and "Buy it" text will be displayed.
+
+The button is right-aligned and appears below the product features section. All links open in a new window.
+
+**Example with custom button image:**
+```yaml
+shop_url: https://example-shop.com/product/ABC124
+shop_icon: https://example.com/custom-button.png
+```
+
+**Example with standard button:**
+```yaml
+shop_url: https://example-shop.com/product/ABC124
+```
 
 [View example Product page](/bulma-clean-theme/products/product2/)
 


### PR DESCRIPTION
This PR adds a Buy it button to the product layout with the following features:

## Features
- Added support for `shop_url` and `shop_icon` in product front matter
- Button displays custom PNG image if `shop_icon` is provided (HTTP link to PNG)
- Falls back to standard Bulma button with shopping cart icon if no custom icon
- Button is right-aligned to match price and product code styling
- Opens links in new window (`target="_blank"`)

## Usage
Add to product front matter:
```yaml
shop_url: "https://example-eshop.com/product/123"
shop_icon: "https://example.com/custom-button.png"  # optional
```

## Changes
- Modified `_layouts/product.html` to include the new button functionality
- Button is conditionally displayed only when `shop_url` is defined
- Maintains existing layout and styling consistency