### PR TITLE
Feature/add multilanguage support with polyglot

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,5 +9,6 @@ group :jekyll_plugins do
     gem "jekyll-paginate"
     gem "jekyll-seo-tag"
     gem 'jekyll-redirect-from'
+    gem "jekyll-polyglot"
 end
 

--- a/_config.yml
+++ b/_config.yml
@@ -92,4 +92,9 @@ social:
   tiktok: https://www.tiktok.com/
   x: https://www.x.com/
   youtube: https://www.youtube.com/
+
+languages: ["en", "de"]
+default_lang: "en"
+exclude_from_localization: ["assets/js", "assets/css"]
+parallel_localization: true
   

--- a/_data/de/docs_menu.yml
+++ b/_data/de/docs_menu.yml
@@ -1,0 +1,88 @@
+- label: Getting Started
+  items:
+    - name: Installation
+      link: /docs/getting-started/installation/
+    - name: Upgrade auf v1
+      link: /docs/getting-started/upgrading-to-v1/
+    - name: Konfiguration
+      link: /docs/getting-started/configuration/
+    - name: Themen
+      link: /docs/getting-started/theming/
+    - name: Seitenleiste
+      link: /docs/getting-started/sidebar/
+    - name: Skripte
+      link: /docs/getting-started/scripts/
+
+- label: Navigation
+  items:
+    - name: Top-Navigation
+      link: /docs/navigation/top-navigation/
+    - name: Fußzeilen-Navigation
+      link: /docs/navigation/footer-navigation/
+    - name: Menüleiste
+      link: /docs/navigation/menubar/
+
+- label: Pages
+  items:
+    - name: Seite erstellen
+      link: /docs/pages/creating-a-page/
+    - name: Hero
+      link: /docs/pages/hero/
+    - name: Inhaltsverzeichnis
+      link: /docs/pages/table-of-contents/
+
+- label: Promo Pages
+  items:
+    - name: Promo-Seite erstellen
+      link: /docs/promo-pages/creating-a-promo-page/
+
+- label: Links Pages
+  items:
+    - name: Links-Seite erstellen
+      link: /docs/links-pages/creating-a-links-page/
+
+- label: Posts
+  items:
+    - name: Beitrag erstellen
+      link: /docs/posts/creating-a-post/
+    - name: Auszug & Zusammenfassung
+      link: /docs/posts/post-excerpt-summary/
+    - name: Serie
+      link: /docs/posts/post-series/
+
+- label: Page Components
+  items: 
+    - name: Hinweise
+      link: /docs/page-components/callouts/
+    - name: Cookie-Banner
+      link: /docs/page-components/cookie-banner/
+    - name: Bildergalerie
+      link: /docs/page-components/image-gallery/
+    - name: Bildmodal
+      link: /docs/page-components/image-modal/
+    - name: Benachrichtigungen
+      link: /docs/page-components/notifications/
+    - name: Präsentationen
+      link: /docs/page-components/showcases/
+    - name: Sponsoren
+      link: /docs/page-components/sponsors/
+    - name: Tabs
+      link: /docs/page-components/tabs/
+    - name: Tags
+      link: /docs/page-components/tags/
+    - name: Video
+      link: /docs/page-components/video/
+
+- label: Products
+  items:
+    - name: Produktseiten
+      link: /docs/products/product-pages/
+    - name: Produktbewertungen
+      link: /docs/products/product-reviews/
+    - name: Kategorieseite
+      link: /docs/products/category-page/
+
+- label: Recipes
+  items:
+    - name: Rezepte
+      link: /docs/recipes/recipes/

--- a/_data/de/home_callouts.yml
+++ b/_data/de/home_callouts.yml
@@ -1,0 +1,12 @@
+style: is-light
+items:
+  - title: Mehrere Seitenlayouts
+    subtitle: Einschließlich Seitenleiste, Menüleiste, Tabs und Hinweise
+    icon: fa-copy
+  - title: Blog enthalten
+    subtitle: Layouts für Blog- und Beitragsseiten enthalten
+    icon: fa-mail-bulk
+  - title: Funktioniert mit GitHub Pages
+    subtitle: Schnell und einfach loslegen
+    icon: fa-github
+    icon_brand: true

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -64,6 +64,21 @@
                         <span>Sponsor</span>
                     </a>
                 {% endif %}
+
+                
+                {% for lang in site.languages %}
+                    {% if lang == site.default_lang %}
+                    <a class="navbar-item is-active" {%static_href%}href="{{ site.baseurl }}{{ page.url }}"{%endstatic_href%}>
+                        <span class="icon"><i class="fas fa-globe"></i></span>
+                        <span>{{ lang | upcase }}</span>
+                    {% else %}
+                    <a class="navbar-item" {%static_href%}href="{{ site.baseurl }}/{{ lang }}{{ page.url }}"{%endstatic_href%}>
+                        <span class="icon"><i class="fas fa-globe"></i></span>
+                        <span>{{ lang | upcase }}</span>
+                        </a>
+                    {% endif %}
+                {% endfor %}
+                
             </div>
         </div>
     </div>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -71,6 +71,7 @@
                         <a class="navbar-item is-active" {%static_href%}href="{{ site.baseurl }}{{ page.url }}"{%endstatic_href%}>
                             <span class="icon"><i class="fas fa-globe"></i></span>
                             <span>{{ lang | upcase }}</span>
+                        </a>
                         {% else %}
                         <a class="navbar-item" {%static_href%}href="{{ site.baseurl }}/{{ lang }}{{ page.url }}"{%endstatic_href%}>
                             <span class="icon"><i class="fas fa-globe"></i></span>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -65,20 +65,21 @@
                     </a>
                 {% endif %}
 
-                
-                {% for lang in site.languages %}
-                    {% if lang == site.default_lang %}
-                    <a class="navbar-item is-active" {%static_href%}href="{{ site.baseurl }}{{ page.url }}"{%endstatic_href%}>
-                        <span class="icon"><i class="fas fa-globe"></i></span>
-                        <span>{{ lang | upcase }}</span>
-                    {% else %}
-                    <a class="navbar-item" {%static_href%}href="{{ site.baseurl }}/{{ lang }}{{ page.url }}"{%endstatic_href%}>
-                        <span class="icon"><i class="fas fa-globe"></i></span>
-                        <span>{{ lang | upcase }}</span>
-                        </a>
-                    {% endif %}
-                {% endfor %}
-                
+                {% if site.languages and site.languages.size > 1 %}
+                    {% for lang in site.languages %}
+                        {% if lang == site.default_lang %}
+                        <a class="navbar-item is-active" {%static_href%}href="{{ site.baseurl }}{{ page.url }}"{%endstatic_href%}>
+                            <span class="icon"><i class="fas fa-globe"></i></span>
+                            <span>{{ lang | upcase }}</span>
+                        {% else %}
+                        <a class="navbar-item" {%static_href%}href="{{ site.baseurl }}/{{ lang }}{{ page.url }}"{%endstatic_href%}>
+                            <span class="icon"><i class="fas fa-globe"></i></span>
+                            <span>{{ lang | upcase }}</span>
+                            </a>
+                        {% endif %}
+                    {% endfor %}
+                 {% endif %}
+
             </div>
         </div>
     </div>

--- a/docs.de.md
+++ b/docs.de.md
@@ -1,0 +1,12 @@
+---
+layout: page
+title: Dokumentation
+menubar: docs_menu
+show_sidebar: false
+lang: de
+permalink: /docs/
+---
+
+Bulma Clean Theme bietet viele Funktionen. Die Dokumentation ist in Kategorien unterteilt, um die Navigation durch die verschiedenen Features zu erleichtern.
+
+Erfahren Sie im Abschnitt [Installation](/bulma-clean-theme/docs/getting-started/installation/), wie Sie das Bulma Clean Theme in Ihr Jekyll-Projekt integrieren.

--- a/index.de.md
+++ b/index.de.md
@@ -1,0 +1,59 @@
+---
+title: Bulma Clean Theme
+subtitle: Dies ist die Demo-Seite für das Bulma Clean Theme
+layout: page
+callouts: home_callouts
+show_sidebar: true
+lang: de
+permalink: /
+---
+
+# Bulma Clean Theme Demo-Website
+
+Diese Website zeigt die Optionen für das Bulma Clean Theme. Das Theme ist als Ruby-Gem verfügbar oder kann mit GitHub Pages verwendet werden.
+
+[![Gem Version](https://badge.fury.io/rb/bulma-clean-theme.svg)](https://badge.fury.io/rb/bulma-clean-theme)
+![Gem](https://img.shields.io/gem/dt/bulma-clean-theme.svg)
+![GitHub Repo stars](https://img.shields.io/github/stars/chrisrhymes/bulma-clean-theme?style=social)
+
+## Wartung und Support
+
+Wenn Sie die Wartung dieses Themes unterstützen möchten, finden Sie das Theme auf GitHub.
+
+[GitHub-Repository ansehen](https://github.com/chrisrhymes/bulma-clean-theme)
+
+[Auf GitHub sponsern](https://github.com/sponsors/chrisrhymes)
+
+## Ruby Gem
+
+Das Ruby-Gem ist auf der RubyGems-Website unter folgender Adresse verfügbar:
+
+[https://rubygems.org/gems/bulma-clean-theme](https://rubygems.org/gems/bulma-clean-theme).
+
+## Dokumentation
+
+Für vollständige Anweisungen siehe die [Dokumentation](/bulma-clean-theme/docs/)
+
+## Seitenlayouts
+
+Diese Demo-Seite zeigt die verfügbaren Seitenlayout-Optionen.
+
+* [Landing Page mit Callouts](/bulma-clean-theme/landing/)
+* [Promo-Seite](/bulma-clean-theme/promo-page/)
+* [Links-Seite](/bulma-clean-theme/links/)
+* [Sponsoren-Seite](/bulma-clean-theme/sponsors/)
+* [Bildergalerie](/bulma-clean-theme/gallery/)
+* [Rezept-Seite](/bulma-clean-theme/example-recipe/)
+* [Blog](/bulma-clean-theme/blog/)
+* [Beitrag](/bulma-clean-theme/2021/10/30/creating-a-post-series/)
+
+## Seitenkomponenten
+
+Standardseiten können auch die folgenden Komponenten verwenden:
+
+* Seitenleiste
+* Menüleiste
+* Tabs
+* Fußzeile
+* Hero
+* Inhaltsverzeichnis

--- a/index.md
+++ b/index.md
@@ -4,6 +4,7 @@ subtitle: This is the demo site for Bulma Clean Theme
 layout: page
 callouts: home_callouts
 show_sidebar: true
+permalink: /
 ---
 
 # Bulma Clean Theme demo website


### PR DESCRIPTION
This PR adds multilanguage support to the theme by using [polyglot](https://github.com/untra/polyglot) 

A trivial language switcher on the top right of the header (this probably needs a bit of love to scale to more languages). If only one language is configured it is not shown

Polyglot works by injecting the language into the URL so `http://localhost:4000/docs` becomes `http://localhost:4000/<lang>/docs`. 

To illustrate how it works I configured english and german and translated the start page and the docs page. All other pages including the posts are still available but untranslated. Polyglot would offer several ways how to organize translated files and even for filtering out untranslated pages for the respective languages. 

A sample screencast how it works is available here. 

https://github.com/user-attachments/assets/c8d1911d-dcc9-4fc8-a77a-82a94dcad3f8

Summary of the changes:

* Add polyglot to the `Gemfile`
* Configure `_config.yml` with polyglot specific values (on windows you might need to disable `parallel_localization` to not freeze up jekyll)
* create translated pages by creating a `index.<lang>.md` or similar
* create translated copies of the `_data/*.yml` files and put them into `_data/<lang>/*.yml`
* add `permalink:` to the frontmatter of the translated pages (if you see directory listings when switching languages, `permalink` is most likely missing) - untranslated pages don't need this
* All pages without a `lang:` in the front matter are assumed to be default language


If you think this is a welcome feature I can also provide some more documentation on it. 

