### PR TITLE
Add blog post links and descriptions to product pages

### DIFF
--- a/_layouts/product.html
+++ b/_layouts/product.html
@@ -69,6 +69,47 @@ layout: default
         </div>
     </div>
 
+    {% assign show_related_posts = page.show_related_posts | default: true %}
+    {% if page.product_code and show_related_posts %}
+        {% assign related_posts = site.posts | where_exp: "post", "post.hidden != true and post.tags contains page.product_code" %}
+        {% if related_posts.size > 0 %}
+            <div class="column is-12">
+                <p class="title is-4">Related Blog Posts</p>
+                <div class="columns is-multiline">
+                    {% for post in related_posts %}
+                        <div class="column is-12-mobile is-6-tablet is-4-desktop">
+                            <div class="card" style="height: 100%; display: flex; flex-direction: column;">
+                                {% if post.image %}
+                                    <div class="card-image">
+                                        <a href="{{ site.baseurl }}{{ post.url }}">
+                                            <img src="{{ post.image }}" alt="{{ post.title }}" style="width: 100%; aspect-ratio: 16 / 9; object-fit: cover; display: block;">
+                                        </a>
+                                    </div>
+                                {% endif %}
+                                <div class="card-content" style="display: flex; flex-direction: column; flex: 1;">
+                                    <div class="content" style="flex: 1;">
+                                        <a class="title is-5" href="{{ site.baseurl }}{{ post.url }}">{{ post.title }}</a>
+                                        <p class="is-size-7 has-text-grey mb-3">{{ post.date | date: '%b %-d, %Y' }}</p>
+                                        {% if post.description %}
+                                            <p>{{ post.description }}</p>
+                                        {% elsif post.summary %}
+                                            {{ post.summary | markdownify }}
+                                        {% else %}
+                                            <p>{{ post.excerpt | strip_html | truncate: 180 }}</p>
+                                        {% endif %}
+                                    </div>
+                                    <div class="mt-4">
+                                        <a href="{{ site.baseurl }}{{ post.url }}" class="button is-primary is-small">Read more</a>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    {% endfor %}
+                </div>
+            </div>
+        {% endif %}
+    {% endif %}
+
     {% if site.data.reviews[page.product_code] %}
         <div class="column is-12">
             <p class="title is-4">Reviews</p>

--- a/docs/products/product-pages.md
+++ b/docs/products/product-pages.md
@@ -82,6 +82,36 @@ buttons:
       text: Buy it
 ```
 
+### Related Blog Posts
+
+Product pages can automatically display related blog posts. The feature matches posts by their tags against the product's `product_code`. Any blog post that includes the product code in its `tags` will appear as a card in the "Related Blog Posts" section below the product description.
+
+Related posts are enabled by default when `product_code` is set. To disable them, add the following to the product's front matter:
+
+```yaml
+show_related_posts: false
+```
+
+Each post card displays:
+- Post image (if available, shown with 16:9 aspect ratio)
+- Post title and date
+- Post description, summary, or excerpt (truncated to 180 characters)
+- A "Read more" link
+
+Cards are displayed in a responsive grid — 1 column on mobile, 2 on tablet, and 3 on desktop.
+
+Hidden posts (`hidden: true` in post front matter) are automatically excluded from the list.
+
+**Example blog post tagged with a product code:**
+```yaml
+---
+title: "New features for Product 1"
+tags: ABC124
+image: /img/blog-post.jpg
+description: A short summary of the post.
+---
+```
+
 [View example Product page](/bulma-clean-theme/products/product2/)
 
 ## Product Collections 


### PR DESCRIPTION
This pull request introduces a new feature that automatically displays related blog posts on product pages by matching blog post tags to the product's `product_code`. The feature is enabled by default and is fully documented, including customization options and display details.

**Feature: Related Blog Posts on Product Pages**

* Product pages now automatically show a "Related Blog Posts" section if the page has a `product_code`. Blog posts are matched by checking if their `tags` include the product code, and hidden posts are excluded. Each related post is displayed as a card with its image, title, date, description/summary/excerpt, and a "Read more" link. The layout is responsive across devices. This feature can be disabled per product page by setting `show_related_posts: false` in the front matter. (`_layouts/product.html`)

**Documentation Updates**

* The documentation for product pages has been updated to explain how the related blog posts feature works, how to disable it, what information is shown in each card, and how to tag blog posts for inclusion. An example configuration is provided for clarity. (`docs/products/product-pages.md`)

**Example of implementation**:
At the end of this page (https://astrometers.eu/products/AMASC01/) you can see list of related blog-posts. It is automatically generated according to product identification. 

<img width="1694" height="1180" alt="image" src="https://github.com/user-attachments/assets/04f5d9c4-6fd5-4892-afb3-68fddb2a9af5" />
